### PR TITLE
fix: Pass relative file source to dry-run

### DIFF
--- a/frameworks/src/foundry/mod.rs
+++ b/frameworks/src/foundry/mod.rs
@@ -105,7 +105,7 @@ impl Interface for Foundry {
         command.args([
             "test",
             "--match-path",
-            &util::strip_prefix(&test_file, context.root)
+            &util::strip_prefix(test_file, context.root)
                 .unwrap()
                 .to_string_lossy(),
         ]);

--- a/frameworks/src/foundry/mod.rs
+++ b/frameworks/src/foundry/mod.rs
@@ -102,7 +102,13 @@ impl Interface for Foundry {
         let mut command = Command::new("forge");
         command.current_dir(context.root);
         command.env("FOUNDRY_FUZZ_RUNS", "1");
-        command.args(["test", "--match-path", &test_file.to_string_lossy()]);
+        command.args([
+            "test",
+            "--match-path",
+            &util::strip_prefix(&test_file, context.root)
+                .unwrap()
+                .to_string_lossy(),
+        ]);
         command.args(&context.opts.args);
 
         debug!("{:?}", command);


### PR DESCRIPTION
The file source is being passed in as an absolute path, `forge --mp` expects a relative path. The result is that currently `forge` will incorrectly report that the dry-run has passed, because it couldn't find any tests.