### PR TITLE
119 error on dump with no db

### DIFF
--- a/core/src/core.rs
+++ b/core/src/core.rs
@@ -170,6 +170,7 @@ fn prepare<Identifier: Applicable + Display + IntoEnumIterator + ToImplementatio
         (None, Vec::new())
     } else {
         let (sqlite, mut past_removals) = sqlite::init(
+            context,
             context.root,
             context.opts.dump,
             context.opts.resume,

--- a/core/src/core.rs
+++ b/core/src/core.rs
@@ -171,7 +171,8 @@ fn prepare<Identifier: Applicable + Display + IntoEnumIterator + ToImplementatio
     } else {
         let (sqlite, mut past_removals) = sqlite::init(
             context.root,
-            !context.opts.dump && !context.opts.reset && !context.opts.resume,
+            context.opts.dump,
+            context.opts.resume,
             context.opts.reset,
         )?;
         past_removals.sort_by(|left, right| left.span.cmp(&right.span));

--- a/core/src/core.rs
+++ b/core/src/core.rs
@@ -173,8 +173,8 @@ fn prepare<Identifier: Applicable + Display + IntoEnumIterator + ToImplementatio
             context,
             context.root,
             context.opts.dump,
-            context.opts.resume,
             context.opts.reset,
+            context.opts.resume,
         )?;
         past_removals.sort_by(|left, right| left.span.cmp(&right.span));
         (Some(sqlite), past_removals)

--- a/core/src/sqlite.rs
+++ b/core/src/sqlite.rs
@@ -68,7 +68,8 @@ impl Removal {
 
 pub(crate) fn init(
     root: &Path,
-    must_not_exist: bool,
+    dump: bool,
+    resume: bool,
     reset: bool,
 ) -> Result<(Sqlite, Vec<crate::Removal>)> {
     let root = Rc::new(root.to_path_buf());
@@ -76,6 +77,14 @@ pub(crate) fn init(
 
     let exists = path_buf.try_exists()?;
 
+    if dump && !exists {
+        bail!(
+            "No sqlite database found at {:?}; please remove the --dump flag",
+            path_buf
+        );
+    }
+
+    let must_not_exist = !resume && !reset;
     if must_not_exist && exists {
         bail!(
             "Found an sqlite database at {:?}; please pass either --reset or --resume",

--- a/core/src/sqlite.rs
+++ b/core/src/sqlite.rs
@@ -70,40 +70,40 @@ pub(crate) fn init(
     context: &LightContext,
     root: &Path,
     dump: bool,
-    resume: bool,
     reset: bool,
+    resume: bool,
 ) -> Result<(Sqlite, Vec<crate::Removal>)> {
     let root = Rc::new(root.to_path_buf());
     let path_buf = root.join("necessist.db");
 
     let exists = path_buf.try_exists()?;
 
-    let nodb_msg = |flag: &str| {
+    let no_db_msg = |flag: &str| {
         format!(
-            "No sqlite database found at {:?} to {}; creating new database",
-            path_buf, flag
+            "No sqlite database found to {} at {:?}; creating new database",
+            flag, path_buf
         )
     };
 
-    match (exists, dump, resume, reset) {
+    match (exists, dump, reset, resume) {
         (true, false, false, false) => bail!(
             "Found an sqlite database at {:?}; please pass either --reset or --resume",
             path_buf
         ),
         (false, true, _, _) => bail!(
-            "No sqlite database found at {:?}; please remove the --dump flag",
+            "--dump was passed, but no sqlite database found at {:?}",
             path_buf
         ),
         (false, _, true, _) => warn(
             context,
             Warning::DatabaseDoesNotExist,
-            &nodb_msg("resume"),
+            &no_db_msg("reset"),
             WarnFlags::ONCE,
         )?,
         (false, _, _, true) => warn(
             context,
             Warning::DatabaseDoesNotExist,
-            &nodb_msg("reset"),
+            &no_db_msg("resume"),
             WarnFlags::ONCE,
         )?,
         _ => (),

--- a/core/src/warn.rs
+++ b/core/src/warn.rs
@@ -16,6 +16,7 @@ use std::{collections::BTreeMap, sync::Mutex};
 #[remain::sorted]
 pub enum Warning {
     All,
+    DatabaseDoesNotExist,
     DryRunFailed,
     FilesChanged,
     IgnoredFunctionsUnsupported,
@@ -176,7 +177,8 @@ pub(crate) fn note(context: &LightContext, msg: &str) {
 fn may_be_bug(warning: Warning) -> bool {
     match warning {
         Warning::All => unreachable!(),
-        Warning::DryRunFailed
+        Warning::DatabaseDoesNotExist
+        | Warning::DryRunFailed
         | Warning::FilesChanged
         | Warning::IgnoredFunctionsUnsupported
         | Warning::IgnoredMacrosUnsupported

--- a/necessist/tests/necessist_db_absent/basic_dump_fail.stderr
+++ b/necessist/tests/necessist_db_absent/basic_dump_fail.stderr
@@ -1,0 +1,1 @@
+Error: --dump was passed, but no sqlite database found at "[CWD]/examples/basic/necessist.db"

--- a/necessist/tests/necessist_db_absent/basic_dump_fail.toml
+++ b/necessist/tests/necessist_db_absent/basic_dump_fail.toml
@@ -1,0 +1,10 @@
+args = ["--root=examples/basic", "--dump"]
+
+[bin]
+name = "necessist"
+
+[fs]
+cwd = "../../.."
+
+[status]
+code = 1

--- a/necessist/tests/necessist_db_absent/basic_reset_warn.stderr
+++ b/necessist/tests/necessist_db_absent/basic_reset_warn.stderr
@@ -1,0 +1,1 @@
+Error: No sqlite database found to reset at "[CWD]/examples/basic/necessist.db"; creating new database

--- a/necessist/tests/necessist_db_absent/basic_reset_warn.toml
+++ b/necessist/tests/necessist_db_absent/basic_reset_warn.toml
@@ -1,0 +1,10 @@
+args = ["--root=examples/basic", "--reset", "--deny=database-does-not-exist"]
+
+[bin]
+name = "necessist"
+
+[fs]
+cwd = "../../.."
+
+[status]
+code = 1

--- a/necessist/tests/necessist_db_absent/basic_resume_warn.stderr
+++ b/necessist/tests/necessist_db_absent/basic_resume_warn.stderr
@@ -1,0 +1,1 @@
+Error: No sqlite database found to resume at "[CWD]/examples/basic/necessist.db"; creating new database

--- a/necessist/tests/necessist_db_absent/basic_resume_warn.toml
+++ b/necessist/tests/necessist_db_absent/basic_resume_warn.toml
@@ -1,0 +1,10 @@
+args = ["--root=examples/basic", "--resume", "--deny=database-does-not-exist"]
+
+[bin]
+name = "necessist"
+
+[fs]
+cwd = "../../.."
+
+[status]
+code = 1

--- a/necessist/tests/necessist_db_present/basic_no_flag_fail.stderr
+++ b/necessist/tests/necessist_db_present/basic_no_flag_fail.stderr
@@ -1,0 +1,1 @@
+Error: Found an sqlite database at "[CWD]/examples/basic/necessist.db"; please pass either --reset or --resume

--- a/necessist/tests/necessist_db_present/basic_no_flag_fail.toml
+++ b/necessist/tests/necessist_db_present/basic_no_flag_fail.toml
@@ -1,0 +1,10 @@
+args = ["--root=examples/basic"]
+
+[bin]
+name = "necessist"
+
+[fs]
+cwd = "../../.."
+
+[status]
+code = 1


### PR DESCRIPTION
Refactor the dump, reset, resume flag, and database existence validation logic. It now does the following:

1. Exits with an error on using the `--dump` flag when the database does not exist
2. Shows warning when running with the `--resume` or `--reset` flag, and the database does not exist
3. Exits with an error when no flag is given but the database exists (this is not new in this PR, it's already there)

closes #119 

Reading on the `trycmd` tests to create one for this PR