### PR TITLE
Fix missing package.json

### DIFF
--- a/frameworks/src/running.rs
+++ b/frameworks/src/running.rs
@@ -43,7 +43,7 @@ impl<T: RunLow> RunHigh for RunAdapter<T> {
     fn dry_run(&self, context: &LightContext, test_file: &Path) -> Result<()> {
         // smoelius: `REQUIRES_NODE_MODULES` is a hack. But at present, I don't know how it should
         // be generalized.
-        if T::REQUIRES_NODE_MODULES {
+        if T::REQUIRES_NODE_MODULES && context.root.join("package.json").try_exists()? {
             ts_utils::install_node_modules(context)?;
         }
 


### PR DESCRIPTION
Addresses #532.

Wasn't quite sure whether to add it to the util function https://github.com/trailofbits/necessist/blob/b8ac93c8789cba24d75864feb0c0dd140c94175f/frameworks/src/ts_utils.rs#L6-L7
or to the `dry_run` function. Decided on the latter, since I imagine hardhat has it's own sanity-checks. Though I'm guessing this will be re-written at some point anyhow.