### PR TITLE
Remove `name` method from `ParseHigh`

### DIFF
--- a/core/src/framework/mod.rs
+++ b/core/src/framework/mod.rs
@@ -26,7 +26,6 @@ pub trait ToImplementation {
 pub trait Interface: Parse + Run {}
 
 pub trait Parse {
-    fn name(&self) -> String;
     fn parse(
         &mut self,
         context: &LightContext,
@@ -56,9 +55,6 @@ pub trait AsRun {
 }
 
 impl<T: AsParse> Parse for T {
-    fn name(&self) -> String {
-        self.as_parse().name()
-    }
     #[cfg_attr(
         dylint_lib = "non_local_effect_before_error_return",
         allow(non_local_effect_before_error_return)

--- a/frameworks/src/parsing.rs
+++ b/frameworks/src/parsing.rs
@@ -318,9 +318,6 @@ impl<T: ParseLow> ParseLow for Rc<RefCell<T>> {
 pub struct ParseAdapter<T>(pub T);
 
 impl<T: ParseLow> ParseHigh for ParseAdapter<T> {
-    fn name(&self) -> String {
-        T::name()
-    }
     fn parse(
         &mut self,
         context: &LightContext,


### PR DESCRIPTION
I can't remember why it was needed.