### PR TITLE
Revert "Bump tree-sitter-go from 0.19.1 to 0.20.0 in /crates_io"

### DIFF
--- a/crates_io/Cargo.lock
+++ b/crates_io/Cargo.lock
@@ -2143,9 +2143,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-go"
-version = "0.20.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad6d11f19441b961af2fda7f12f5d0dac325f6d6de83836a1d3750018cc5114"
+checksum = "71967701c8214be4aa77e0260e98361e6fd71ceec1d9d03abb37a22c9f60d0ff"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/frameworks/Cargo.toml
+++ b/frameworks/Cargo.toml
@@ -39,7 +39,7 @@ solang-parser = "=0.3.1"
 
 # Go
 tree-sitter = "0.20"
-tree-sitter-go = "0.20"
+tree-sitter-go = "0.19"
 
 # Hardhat TS
 swc_core = { version = "0.79", features = ["common", "ecma_ast", "ecma_parser", "ecma_visit"] }


### PR DESCRIPTION
Reverts trailofbits/necessist#632