### PR TITLE
Unpin `markdown-link-check`

### DIFF
--- a/necessist/tests/ci.rs
+++ b/necessist/tests/ci.rs
@@ -146,10 +146,8 @@ fn license() {
 fn markdown_link_check() {
     let tempdir = tempdir().unwrap();
 
-    // smoelius: Pin `markdown-link-check` to version 3.10.3 until the following issue is resolved:
-    // https://github.com/tcort/markdown-link-check/issues/246
     Command::new("npm")
-        .args(["install", "markdown-link-check@3.10.3"])
+        .args(["install", "markdown-link-check"])
         .current_dir(&tempdir)
         .assert()
         .success();


### PR DESCRIPTION
https://github.com/tcort/markdown-link-check/releases/tag/v3.11.2