### PR TITLE
Add clarifying comments for progress bar unwrap usage

### DIFF
--- a/core/src/core.rs
+++ b/core/src/core.rs
@@ -173,7 +173,7 @@ pub fn necessist<Identifier: Applicable + Display + IntoEnumIterator + ToImpleme
         progress.as_ref().unwrap().println(msg);
     };
 
-    // Only set this function as the printer when progress exists
+    // Only set this function as the printer when `progress` exists
     if progress.is_some() {
         context.println = &progress_println;
         context.progress = progress.as_ref();

--- a/core/src/core.rs
+++ b/core/src/core.rs
@@ -167,10 +167,13 @@ pub fn necessist<Identifier: Applicable + Display + IntoEnumIterator + ToImpleme
         };
 
     let progress_println = |msg: &dyn AsRef<str>| {
+        // SAFETY: This closure should only be called when `progress` is `Some`.
+        // The unwrap is intentional - we want to panic if this invariant is violated.
         #[allow(clippy::unwrap_used)]
         progress.as_ref().unwrap().println(msg);
     };
 
+    // Only set this function as the printer when progress exists
     if progress.is_some() {
         context.println = &progress_println;
         context.progress = progress.as_ref();


### PR DESCRIPTION
## Description
This PR adds documentation to clarify the intentional design of the progress printing code in `core/src/core.rs`. It adds comments to explain that the unwrap is intentional and documents the expected precondition that the closure should only be called when `progress` is `Some`.

## Changes
- Add a SAFETY comment explaining the intentional use of unwrap
- Document that the unwrap will panic if the invariant is violated (by design)
- Add a comment about when the function is set as the printer

## Motivation
These changes improve code clarity by making the safety requirements and constraints explicit through documentation, while maintaining the current behavior where unwrap is used as a fail-fast mechanism for detecting incorrect usage.

## Related Issues
Fixes #1496