### PR TITLE
Fix typo in README.md under Configuration files section

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ A configuration file allows one to tailor Necessist's behavior with respect to a
 
   - `Method`: Ignore only if the path matches an `ignored_methods` pattern.
 
-- `ignored_tests`: A list of strings. A test whose name exactly matches a string in the list is ignored. For Mocha-based frameworks (e.g., Anchor and Hardhat), a test name is consider to be a message passed to `it`.
+- `ignored_tests`: A list of strings. A test whose name exactly matches a string in the list is ignored. For Mocha-based frameworks (e.g., Anchor and Hardhat), a test name is considered to be a message passed to `it`.
 
 - `walkable_functions`: A list of strings interpreted as [patterns]. If a test calls a function that matches the pattern, and the function is declared in the same file as the test, then statements and method calls are removed from the function as though it were a test.
 


### PR DESCRIPTION
This PR corrects a minor typo in the README.md under the Configuration files section, changing "a test name is consider to be" to "a test name is considered to be." Fixes #1536 