### PR TITLE
Accept command line paths that are not valid Unicode

### DIFF
--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -49,7 +49,7 @@ pub struct Opts<Identifier: Clone + Send + Sync + ValueEnum + 'static> {
     #[clap(long, help = "Resume from the sqlite database")]
     resume: bool,
     #[clap(long, help = "Root directory of the project under test")]
-    root: Option<String>,
+    root: Option<PathBuf>,
     #[clap(
         long,
         help = "Maximum number of seconds to run any test; 60 is the default, 0 means no timeout"
@@ -62,7 +62,7 @@ pub struct Opts<Identifier: Clone + Send + Sync + ValueEnum + 'static> {
         help = "Test files or directories to mutilate; if `--root <ROOT>` is passed, relative \
                 paths are interpreted relative to <ROOT>"
     )]
-    zsource_files: Vec<String>,
+    zsource_files: Vec<PathBuf>,
     #[clap(
         last = true,
         name = "ARGS",
@@ -96,8 +96,7 @@ impl<Identifier: Clone + Send + Sync + ValueEnum> From<Opts<Identifier>>
             zzargs,
         } = opts;
         let framework = framework.unwrap_or_default();
-        let root = root.map(PathBuf::from);
-        let source_files = zsource_files.iter().map(PathBuf::from).collect::<Vec<_>>();
+        let source_files = zsource_files;
         let args = zzargs;
         (
             Necessist {

--- a/necessist/src/main.rs
+++ b/necessist/src/main.rs
@@ -6,14 +6,17 @@ use anyhow::Result;
 use clap::Parser;
 use necessist_backends::Identifier;
 use necessist_core::{Necessist, cli, framework::Auto, necessist};
-use std::env::args;
+use std::env::args_os;
 
 mod backends;
 
 fn main() -> Result<()> {
     env_logger::init();
 
-    let (opts, framework): (Necessist, Auto<Identifier>) = cli::Opts::parse_from(args()).into();
+    // `args_os` rather than `args` because the latter panics on an argument that is not valid
+    // Unicode. Note that `--root <ROOT>` and `<TEST_FILES_OR_DIRS>` are both paths, which need not
+    // be valid Unicode.
+    let (opts, framework): (Necessist, Auto<Identifier>) = cli::Opts::parse_from(args_os()).into();
 
     necessist(&opts, framework)
 }


### PR DESCRIPTION
`std::env::args` panics on an argument that is not valid Unicode. Use `args_os` instead, and type `--root <ROOT>` and `<TEST_FILES_OR_DIRS>` as `PathBuf` so that Clap need not convert them to `String`.