### PR TITLE
Exit with 2 rather than 1 on error

### DIFF
--- a/necessist/src/main.rs
+++ b/necessist/src/main.rs
@@ -2,15 +2,18 @@
 #![warn(clippy::unwrap_used)]
 #![warn(clippy::panic)]
 
-use anyhow::Result;
 use clap::Parser;
 use necessist_backends::Identifier;
 use necessist_core::{Necessist, cli, framework::Auto, necessist};
-use std::env::args_os;
+use std::{env::args_os, process::ExitCode};
 
 mod backends;
 
-fn main() -> Result<()> {
+// Exit codes follow the convention used by `grep` and `diff`: 0 means the question was answered
+// affirmatively, 1 means it was answered negatively, and 2 means an error occurred. Errors are
+// mapped to 2 here rather than relying on `Termination`, which would map them to 1. Note that Clap
+// also exits with 2 on a usage error.
+fn main() -> ExitCode {
     env_logger::init();
 
     // `args_os` rather than `args` because the latter panics on an argument that is not valid
@@ -18,5 +21,12 @@ fn main() -> Result<()> {
     // be valid Unicode.
     let (opts, framework): (Necessist, Auto<Identifier>) = cli::Opts::parse_from(args_os()).into();
 
-    necessist(&opts, framework)
+    match necessist(&opts, framework) {
+        Ok(()) => ExitCode::SUCCESS,
+        // `{:?}` is what `Termination` uses, and is what produces `anyhow`'s `Caused by` sections.
+        Err(error) => {
+            eprintln!("Error: {error:?}");
+            ExitCode::from(2)
+        }
+    }
 }

--- a/necessist/tests/necessist_db_absent/basic_dump_fail.toml
+++ b/necessist/tests/necessist_db_absent/basic_dump_fail.toml
@@ -1,8 +1,9 @@
 args = ["--root=fixtures/basic", "--dump"]
 
-status = "failed"
-
 stdout = ""
 
 [fs]
 cwd = "../../.."
+
+[status]
+code = 2

--- a/necessist/tests/necessist_db_absent/basic_reset_warn.toml
+++ b/necessist/tests/necessist_db_absent/basic_reset_warn.toml
@@ -1,6 +1,7 @@
 args = ["--root=fixtures/basic", "--reset", "--deny=database-does-not-exist"]
 
-status = "failed"
-
 [fs]
 cwd = "../../.."
+
+[status]
+code = 2

--- a/necessist/tests/necessist_db_absent/basic_resume_warn.toml
+++ b/necessist/tests/necessist_db_absent/basic_resume_warn.toml
@@ -1,6 +1,7 @@
 args = ["--root=fixtures/basic", "--resume", "--deny=database-does-not-exist"]
 
-status = "failed"
-
 [fs]
 cwd = "../../.."
+
+[status]
+code = 2

--- a/necessist/tests/necessist_db_absent/invalid_pattern.toml
+++ b/necessist/tests/necessist_db_absent/invalid_pattern.toml
@@ -1,8 +1,9 @@
 args = ["--no-sqlite", "--root=fixtures/invalid_pattern"]
 
-status = "failed"
-
 stdout = ""
 
 [fs]
 cwd = "../../.."
+
+[status]
+code = 2

--- a/necessist/tests/necessist_db_absent/run_test_failed_deny.toml
+++ b/necessist/tests/necessist_db_absent/run_test_failed_deny.toml
@@ -4,7 +4,8 @@ args = [
     "--deny=run-test-failed",
 ]
 
-status = "failed"
-
 [fs]
 cwd = "../../.."
+
+[status]
+code = 2

--- a/necessist/tests/necessist_db_absent/unknown_keys.toml
+++ b/necessist/tests/necessist_db_absent/unknown_keys.toml
@@ -1,8 +1,9 @@
 args = ["--no-sqlite", "--root=fixtures/unknown_keys"]
 
-status = "failed"
-
 stdout = ""
 
 [fs]
 cwd = "../../.."
+
+[status]
+code = 2

--- a/necessist/tests/necessist_db_present/basic_no_flag_fail.toml
+++ b/necessist/tests/necessist_db_present/basic_no_flag_fail.toml
@@ -1,9 +1,10 @@
 args = ["--root=fixtures/basic"]
 
-status = "failed"
-
 [bin]
 name = "necessist"
 
 [fs]
 cwd = "../../.."
+
+[status]
+code = 2

--- a/necessist/tests/trycmd.rs
+++ b/necessist/tests/trycmd.rs
@@ -133,6 +133,15 @@ fn check_toml_files() {
         let stderr = document.as_table().and_then(|table| table.get("stderr"));
         assert!(status.is_some() || stderr.is_some());
 
+        if let Some(status) = status {
+            let code = status
+                .as_table()
+                .and_then(|table| table.get("code"))
+                .and_then(toml::Value::as_integer)
+                .unwrap();
+            assert_eq!(2, code);
+        }
+
         for stream in ["stdout", "stderr"] {
             let inline_empty = document
                 .as_table()


### PR DESCRIPTION
Follow the convention used by `grep` and `diff`: 0 means the question was answered affirmatively, 1 means it was answered negatively, and 2 means an error occurred. Note that Clap already exits with 2 on a usage error.