### PR TITLE
Make Span::source_text return an error instead of indexing out of bounds

### DIFF
--- a/core/src/span.rs
+++ b/core/src/span.rs
@@ -148,7 +148,12 @@ impl Span {
         }
     }
 
-    /// Returns the spanned text.
+    /// Returns the spanned text, or an error if the span's offsets are not a valid range within
+    /// the contents
+    ///
+    /// The contents are cached per path while each backend rereads the file, so even a span just
+    /// produced by parsing can fall outside them. An `Ok` is not proof that the span is current
+    /// either: an overlong column is clamped rather than rejected.
     pub fn source_text(&self) -> Result<String> {
         let contents = self.source_file.contents();
 
@@ -162,8 +167,15 @@ impl Span {
             .borrow_mut()
             .offsets_from_span(self);
 
-        let bytes = &contents.as_bytes()[start..end];
-        let text = std::str::from_utf8(bytes)?;
+        let text = contents.get(start..end).ok_or_else(|| {
+            anyhow!(
+                "`{}..{}` is not a valid range within the contents of `{}`; the file may have \
+                 changed since it was read",
+                start,
+                end,
+                self.source_file.display()
+            )
+        })?;
 
         Ok(text.to_owned())
     }
@@ -201,5 +213,61 @@ impl ToInternalSpan for proc_macro2::Span {
             start: self.start(),
             end: self.end(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use elaborate::std::fs::write_wc;
+    use testing::tempfile_util::tempdir;
+
+    #[test]
+    fn source_text_returns_the_text_of_a_span_within_the_contents() {
+        let tempdir = tempdir().unwrap();
+        let root = Rc::new(tempdir.path().to_path_buf());
+        write_wc(root.join("f.rs"), "aaaa\nbb\n").unwrap();
+
+        let span = Span::parse(&root, "f.rs:1:1-1:3").unwrap();
+
+        assert_eq!("aa", span.source_text().unwrap());
+    }
+
+    #[test]
+    fn source_text_returns_an_error_for_an_inverted_span() {
+        let tempdir = tempdir().unwrap();
+        let root = Rc::new(tempdir.path().to_path_buf());
+        write_wc(root.join("f.rs"), "aaaa\nbb\n").unwrap();
+
+        // Ends before it starts. The offsets are both within the contents, so a check that looked
+        // only at the file's length would let this through and then index with `start > end`.
+        let span = Span::parse(&root, "f.rs:2:2-1:2").unwrap();
+
+        let error = span.source_text().unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("is not a valid range within the contents of"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn source_text_returns_an_error_for_a_span_exceeding_the_contents() {
+        let tempdir = tempdir().unwrap();
+        let root = Rc::new(tempdir.path().to_path_buf());
+        // No trailing newline: it is what makes the computed offset exceed the file's length.
+        write_wc(root.join("f.rs"), "aaaa\nbb").unwrap();
+
+        let span = Span::parse(&root, "f.rs:3:1-3:5").unwrap();
+
+        // Before this change, indexing the contents at this offset panicked.
+        let error = span.source_text().unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("is not a valid range within the contents of"),
+            "{error}"
+        );
     }
 }

--- a/necessist/tests/general/main.rs
+++ b/necessist/tests/general/main.rs
@@ -175,6 +175,78 @@ fn kill() -> Command {
     command
 }
 
+// `Span::source_text` must report a span it cannot read rather than index past the contents. Two
+// calls of `necessist` arrange one: `SOURCE_FILES` is never invalidated, so the second call slices
+// the first call's contents while the backend reparses the file as it now stands, and the span's
+// coordinates and text then come from different reads. The two reads within a single parse leave
+// the same window open, and are not covered here; opening it on demand would need a hook in
+// `SourceFile`.
+#[test]
+fn source_text_reports_a_span_exceeding_the_cached_contents() {
+    use elaborate::std::fs::{create_dir_all_wc, write_wc};
+    use necessist_backends::Identifier;
+    use necessist_core::{Necessist, framework::Auto, necessist};
+
+    const MANIFEST: &str = r#"[package]
+name = "repro"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[workspace]
+"#;
+    const SHORT: &str = r"#[test]
+fn t() {
+    let mut n = 0;
+    n += 1;
+    assert!(n > 0);
+}
+";
+    const LONG: &str = r"#[test]
+fn t() {
+    let mut n = 0;
+    n += 1;
+    assert!(n > 0);
+}
+
+#[test]
+fn u() {
+    let mut n = 0;
+    n += 1;
+    assert!(n > 0);
+}";
+
+    let tempdir = tempdir().unwrap();
+    let root = tempdir.path().join("repro");
+    create_dir_all_wc(root.join("src")).unwrap();
+    write_wc(root.join("Cargo.toml"), MANIFEST).unwrap();
+
+    let opts = Necessist {
+        root: Some(root.clone()),
+        dump_candidates: true,
+        no_sqlite: true,
+        ..Default::default()
+    };
+
+    // First call reads and caches the short file.
+    write_wc(root.join("src/lib.rs"), SHORT).unwrap();
+    necessist(&opts, Auto::<Identifier>::default()).unwrap();
+
+    // The file grows. The cache still holds the short contents, but the backend parses the long
+    // ones, so `dump_candidates` reaches for a span that is not within what it holds.
+    //
+    // Before this change: `panicked at core/src/span.rs:165:41: range start index .. out of range`.
+    // After it: an ordinary error.
+    write_wc(root.join("src/lib.rs"), LONG).unwrap();
+    let error = necessist(&opts, Auto::<Identifier>::default()).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("is not a valid range within the contents of"),
+        "{error}"
+    );
+}
+
 #[test]
 fn tests_are_not_rebuilt() {
     run_basic_test(|| {


### PR DESCRIPTION
`Span::source_text` indexes a source file's cached contents by byte offset:

```rust
let bytes = &contents.as_bytes()[start..end];
```

The offsets do not come from those contents. `ParseAdapter::parse` reads the file once through
`SourceFile::new`, which caches it for the lifetime of the thread, and then hands the *path* to
`ParseLow::parse_source_file`, so every backend reads the file again. Candidate spans come from the
second read; `source_text` slices the first. When the two disagree the slice is out of range:

```
panicked at core/src/span.rs:165:41:
range start index 71 out of range for slice of length 70
```

`SOURCE_FILES` is never invalidated, so this is deterministic: two calls of `necessist()` on one
thread with a file that grows in between are enough. The test this PR adds does that.

### This change

`source_text` uses `str::get` and returns an error instead of indexing:

```rust
let text = contents.get(start..end).ok_or_else(|| {
    anyhow!(
        "`{}..{}` is not a valid range within the contents of `{}`; the file may have \
         changed since it was read",
        start,
        end,
        self.source_file.display()
    )
})?;
```

`str::get` also rejects an inverted range and an offset that is not on a UTF-8 boundary, which
makes the `from_utf8` step unnecessary. Three unit tests cover the success case, a span past the
end of the contents, and an inverted span.

The signature is unchanged and no caller is modified. The `Err` variant was previously unreachable
in practice, so what changes is the behavior on the previously panicking path: the three callers
that use `?` now propagate an error where the process used to abort, and the two that already have
an `else` branch take it.

The change is limited to the slice. `source_text` can still panic before reaching it, inside
`offsets_from_span`, and a clamped column can still make it return an `Ok` holding the wrong text;
both belong to the offset calculation rather than to this function. It also does not fix the double
read, which would mean changing `ParseLow::parse_source_file` to take contents rather than a path
and updating every backend.
