### PR TITLE
Clarify necessist-audit directory and database scope

### DIFF
--- a/core/skills/necessist-audit/SKILL.md
+++ b/core/skills/necessist-audit/SKILL.md
@@ -2,7 +2,7 @@
 name: necessist-audit
 description: Use to audit Necessist results, running Necessist first if needed, and investigate whether passing removals reveal bugs in code or tests, including test-harness bugs that let tests pass without checking intended behavior.
 metadata:
-  version: "4.0.0"
+  version: "4.0.1"
   license: AGPL-3.0-only
   compatibility:
     requires:
@@ -28,7 +28,9 @@ Analyze only removals whose outcome is `passed`.
 
 ## Locate results
 
-Look for `necessist.db` in the current directory. If it does not exist, run `necessist` there and use the resulting database. If Necessist is unavailable or the run fails, report the error and ask the user how to proceed.
+Use the directory specified by the user; otherwise use the current working directory. The active editor file does not limit scope. Audit every passing removal in that directory’s database unless the user explicitly limits the scope.
+
+Look for `necessist.db` in that directory. If it does not exist, run `necessist` there and use the resulting database. If Necessist is unavailable or the run fails, report the error and ask the user how to proceed.
 
 Read passing removals with `necessist --dump`. Use read-only SQLite queries only if needed.
 

--- a/core/skills/necessist-audit/SKILL.md
+++ b/core/skills/necessist-audit/SKILL.md
@@ -2,7 +2,7 @@
 name: necessist-audit
 description: Use to audit Necessist results, running Necessist first if needed, and investigate whether passing removals reveal bugs in code or tests, including test-harness bugs that let tests pass without checking intended behavior.
 metadata:
-  version: "4.0.1"
+  version: "4.0.0"
   license: AGPL-3.0-only
   compatibility:
     requires:


### PR DESCRIPTION
The audit skill leaves the target directory implicit, allowing editor context to be mistaken for a file-level scope. Clarify that a user-specified directory takes precedence over the working directory, and that the audit covers every passing removal in its database unless the user explicitly narrows scope. The active editor file does not limit the audit.

Update database lookup to use that selected directory.

Validation: skill-creator quick validation and `git diff --check` passed. This wording change addresses scope selection; it does not claim to fix the reported execution freeze.

This PR was created by OpenAI Codex at the user's request.
